### PR TITLE
normalize paths resolved via import map

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -111,7 +111,7 @@ func TestImportMapResolveError(t *testing.T) {
 func TestImportMapSuccess(t *testing.T) {
 	output, rc := run([]string{"--import-map=test/im_ok.json", "--minify", "test/js/root.js"})
 	assertEqual(t, rc, 0)
-	assertEqual(t, output, "(()=>{var o=\"@sib\";var r=\"@lib\";var t=\"@lib/ref\";var b=\"@sub:a\";var e=\"@sub:b\";var f=\"@sub:c\";console.log(o,r,t,b,e,f);})();\n")
+	assertEqual(t, output, "(()=>{var r=\"@sib\";var t=\"@lib\";var b=\"@lib/ref\";var o=\"@sub:a\";var e=o+\"+@sub:b\";var f=\"@sub:c\";console.log(r,t,b,o,e,f);})();\n")
 }
 
 func TestSvelteError(t *testing.T) {

--- a/internal/cli/test/js/sub/b.js
+++ b/internal/cli/test/js/sub/b.js
@@ -1,1 +1,3 @@
-export default "@sub:b";
+import a from './a.js';
+
+export default a + "+@sub:b";

--- a/internal/importmap/resolver.go
+++ b/internal/importmap/resolver.go
@@ -62,7 +62,7 @@ func (m *importMap) resolve(specifier string) (string, error) {
 	if len(result) == 0 {
 		return "", fmt.Errorf("Unable to resolve specifier '%s'", specifier)
 	}
-	return result, nil
+	return filepath.Clean(result), nil
 }
 
 func (m *importMap) isRelativeOrAbsolute(specifier string) bool {


### PR DESCRIPTION
This fixes a bug where the same module could be included twice in the
output bundle: When the module was imported with a relative specifier
(./mod.js) and with a bare specifier (stuff/mod.js), the full module
path would be resolved by esbuild in the first case and by the import
map plugin in the second. However, the import map plugin would return a
semantically equivalent, but different, path string (e.g.
/src/stuff/mod.js vs. /src/./stuff/mod.js) which apparently made esbuild
process it as two distinct modules.